### PR TITLE
Update spi definition for Zephyr 3.2+ compatibility

### DIFF
--- a/config/boards/shields/hillside46/boards/nice_nano.overlay
+++ b/config/boards/shields/hillside46/boards/nice_nano.overlay
@@ -4,13 +4,27 @@
 
 #include <dt-bindings/led/led.h>
 
-&spi1 {
+&pinctrl {
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	mosi-pin = <6>;
-	// Unused pins, needed for SPI def, but not used by ws2812 driver.
-	sck-pin = <5>;
-	miso-pin = <7>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
@@ -24,10 +38,10 @@
 		chain-length = <4>; /* arbitrary; change at will */
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		color-mapping = <LED_COLOR_ID_GREEN
+							LED_COLOR_ID_RED
+							LED_COLOR_ID_BLUE>;
+		};
 };
 
 / {

--- a/config/boards/shields/hillside46/boards/nice_nano_v2.overlay
+++ b/config/boards/shields/hillside46/boards/nice_nano_v2.overlay
@@ -4,13 +4,27 @@
 
 #include <dt-bindings/led/led.h>
 
-&spi1 {
+&pinctrl {
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	mosi-pin = <6>;
-	// Unused pins, needed for SPI def, but not used by ws2812 driver.
-	sck-pin = <5>;
-	miso-pin = <7>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
@@ -24,10 +38,10 @@
 		chain-length = <4>; /* arbitrary; change at will */
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		color-mapping = <LED_COLOR_ID_GREEN
+							LED_COLOR_ID_RED
+							LED_COLOR_ID_BLUE>;
+		};
 };
 
 / {

--- a/config/boards/shields/hillside48/boards/nice_nano.overlay
+++ b/config/boards/shields/hillside48/boards/nice_nano.overlay
@@ -4,13 +4,27 @@
 
 #include <dt-bindings/led/led.h>
 
-&spi1 {
+&pinctrl {
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	mosi-pin = <6>;
-	// Unused pins, needed for SPI def, but not used by ws2812 driver.
-	sck-pin = <5>;
-	miso-pin = <7>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
@@ -24,10 +38,10 @@
 		chain-length = <5>; /* arbitrary; change at will */
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		color-mapping = <LED_COLOR_ID_GREEN
+							LED_COLOR_ID_RED
+							LED_COLOR_ID_BLUE>;
+		};
 };
 
 / {

--- a/config/boards/shields/hillside48/boards/nice_nano_v2.overlay
+++ b/config/boards/shields/hillside48/boards/nice_nano_v2.overlay
@@ -4,13 +4,27 @@
 
 #include <dt-bindings/led/led.h>
 
-&spi1 {
+&pinctrl {
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	mosi-pin = <6>;
-	// Unused pins, needed for SPI def, but not used by ws2812 driver.
-	sck-pin = <5>;
-	miso-pin = <7>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
@@ -24,10 +38,10 @@
 		chain-length = <5>; /* arbitrary; change at will */
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		color-mapping = <LED_COLOR_ID_GREEN
+							LED_COLOR_ID_RED
+							LED_COLOR_ID_BLUE>;
+		};
 };
 
 / {

--- a/config/boards/shields/hillside52/boards/nice_nano.overlay
+++ b/config/boards/shields/hillside52/boards/nice_nano.overlay
@@ -4,13 +4,27 @@
 
 #include <dt-bindings/led/led.h>
 
-&spi1 {
+&pinctrl {
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	mosi-pin = <6>;
-	// Unused pins, needed for SPI def, but not used by ws2812 driver.
-	sck-pin = <5>;
-	miso-pin = <7>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
@@ -24,10 +38,10 @@
 		chain-length = <5>; /* arbitrary; change at will */
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		color-mapping = <LED_COLOR_ID_GREEN
+							LED_COLOR_ID_RED
+							LED_COLOR_ID_BLUE>;
+		};
 };
 
 / {

--- a/config/boards/shields/hillside52/boards/nice_nano_v2.overlay
+++ b/config/boards/shields/hillside52/boards/nice_nano_v2.overlay
@@ -4,13 +4,27 @@
 
 #include <dt-bindings/led/led.h>
 
-&spi1 {
+&pinctrl {
+	spi3_default: spi3_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+			low-power-enable;
+		};
+	};
+};
+
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	mosi-pin = <6>;
-	// Unused pins, needed for SPI def, but not used by ws2812 driver.
-	sck-pin = <5>;
-	miso-pin = <7>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
@@ -24,10 +38,10 @@
 		chain-length = <5>; /* arbitrary; change at will */
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
-                color-mapping = <LED_COLOR_ID_GREEN
-                                 LED_COLOR_ID_RED
-                                 LED_COLOR_ID_BLUE>;
-        };
+		color-mapping = <LED_COLOR_ID_GREEN
+							LED_COLOR_ID_RED
+							LED_COLOR_ID_BLUE>;
+		};
 };
 
 / {


### PR DESCRIPTION
This branch updates the SPI definition to use `&pinctrl` which is a necessary change for [ZMK using Zephyr 3.2 or greater](https://zmk.dev/blog/2023/04/06/zephyr-3-2#boardshield-changes). The update essentially replicates the [example code in the ZMK docs](https://zmk.dev/docs/features/underglow#nrf52-based-boards).

I've tested this change and confirmed that it builds/runs when using the current ZMK `main` branch, and the underglow LEDs work as expected on my Hillside46.

